### PR TITLE
Change logo to 🗣️

### DIFF
--- a/static/home.html
+++ b/static/home.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="icon" href="/icon.svg" type="image/svg+xml">
 </head>
 
 <body>

--- a/static/icon.svg
+++ b/static/icon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><filter id='shadow' color-interpolation-filters="sRGB">
-    <feDropShadow dx="0" dy="0" stdDeviation="5" flood-opacity="1" flood-color="white"/>
-    <feDropShadow dx="0" dy="0" stdDeviation="5" flood-opacity="1" flood-color="white"/>
-    <feDropShadow dx="0" dy="0" stdDeviation="5" flood-opacity="1" flood-color="white"/>
-    <feDropShadow dx="0" dy="0" stdDeviation="5" flood-opacity="1" flood-color="white"/>
-</filter><text y=".9em" filter="url(#shadow)" font-size="90">🗣️</text></svg>
+    <feDropShadow dx="2" dy="2" stdDeviation="0" flood-opacity="1" flood-color="white"/>
+    <feDropShadow dx="-2" dy="-2" stdDeviation="0" flood-opacity="1" flood-color="white"/>
+    <feDropShadow dx="2" dy="-2" stdDeviation="0" flood-opacity="1" flood-color="white"/>
+    <feDropShadow dx="-2" dy="2" stdDeviation="0" flood-opacity="1" flood-color="white"/>
+</filter><text y="1em" filter="url(#shadow)" font-size="80">🗣️</text></svg>

--- a/static/icon.svg
+++ b/static/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><filter id='shadow' color-interpolation-filters="sRGB">
+    <feDropShadow dx="0" dy="0" stdDeviation="5" flood-opacity="1" flood-color="white"/>
+    <feDropShadow dx="0" dy="0" stdDeviation="5" flood-opacity="1" flood-color="white"/>
+    <feDropShadow dx="0" dy="0" stdDeviation="5" flood-opacity="1" flood-color="white"/>
+    <feDropShadow dx="0" dy="0" stdDeviation="5" flood-opacity="1" flood-color="white"/>
+</filter><text y=".9em" filter="url(#shadow)" font-size="90">🗣️</text></svg>


### PR DESCRIPTION
**Change logo to 🗣️**
Why?
Changing logo to 🗣️ will give more brand recognition to our project compared to a random clip art of a chat, as it is unique. We can, for the time being, keep it as a fallback for the two people who still use desktop Safari in 2024. To make the logo visible, I added a few drop shadows so it can be seen from black backgrounds.
**Screenshot**
![image](https://github.com/sergeant-savage/chatter/assets/72636637/bc567975-6c74-4194-8839-e35d6b078bc5)
As the emoji is browser dependent, it is just rendering text, which is better legally then keeping 🗣️as a logo, legally speaking, I guess.

*Peace, love, and 🗣️*