### PR TITLE
Update Shuttle dependencies in README.md

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 ws = "0.9.2"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
-shuttle-runtime = "0.27.0"
-shuttle-axum = "0.27.0"
+shuttle-runtime = "0.43.0"
+shuttle-axum = "0.43.0"
 tokio = "1.26"


### PR DESCRIPTION
The service is currently down seemingly due to out of date Shuttle-related dependencies. 